### PR TITLE
Refresh endpoint now AllowAnonymous; Log4Net logging static function correction;

### DIFF
--- a/IdentityExp1/Controllers/JwtController.cs
+++ b/IdentityExp1/Controllers/JwtController.cs
@@ -113,6 +113,7 @@ namespace IdentityExp1.Controllers
         ///  sRefreshToken=eyAahHen2djce...
         /// </remarks>
         [HttpPost]
+        [AllowAnonymous]
         public async Task<IActionResult> Refresh(string sRefreshToken)
         {
             var prefix = "Refresh() - ";
@@ -448,7 +449,7 @@ namespace IdentityExp1.Controllers
         [HttpGet]
         //[AllowAnonymous] // Default lockdown, user must be authenticated
         public IActionResult TestB()
-        { return Ok($"TestB Accessible to Unauthenticated Users; {DateTime.UtcNow}; " + diagnosticUserDetails()); }
+        { return Ok($"TestB Inaccessible to Unauthenticated Users; {DateTime.UtcNow}; " + diagnosticUserDetails()); }
 
         [HttpGet]
         [Authorize(Roles = "USER")] // Only authenticated users those with 'User' role

--- a/IdentityExp1/Logging/log4Net/Log4NetAsyncLog.cs
+++ b/IdentityExp1/Logging/log4Net/Log4NetAsyncLog.cs
@@ -275,7 +275,7 @@ namespace NZ01
         public static int ThresholdLevelWarn()
         { return _thresholdLevelWarn; }
 
-        public int ThresholdLevelError(int qSize)
+        public static int ThresholdLevelError(int qSize)
         {
             _thresholdLevelError = qSize;
             setQSizeFormatter();

--- a/IdentityExp1/Startup.cs
+++ b/IdentityExp1/Startup.cs
@@ -15,7 +15,7 @@ using Microsoft.AspNetCore.Mvc;
 using IdentityExp1.Models;
 using Microsoft.Extensions.Configuration;
 using NZ01;
-using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens; // SymmetricSecurityKey
 using System.Text;
 using System.Security.Claims;
 using AspNetCoreRateLimit;
@@ -41,7 +41,6 @@ namespace IdentityExp1
 
         public void ConfigureServices(IServiceCollection services)
         {
-
             ///////////////////////////////////////////////////////////////////
             // Classes required for Identity
             //
@@ -230,6 +229,7 @@ namespace IdentityExp1
 
             app.UseStaticFiles();
 
+            // HTTPS SSL (certification requirement)
             // LetsEncrypt Acme Challenge:
             // Let's Encrypt will test whether or not you own a website by writing something to the 
             // site and expecting it to be available.  You have to make that directory available.


### PR DESCRIPTION
BRANCH: 2017-08-04_LT3_RefreshAllowAnonymous_LoggingCorrection

CHANGED: IdentityExp1/Controllers/JwtController.cs
 - Refresh() now allows anonymous, as you only refresh when you are logged out.
 - TestB() corrected text.

CHANGED: IdentityExp1/Logging/log4Net/Log4NetAsyncLog.cs
 - ThresholdLevelError made static, as a correction.

CHANGED: IdentityExp1/Startup.cs
 - Comments updated.