### PR TITLE
Log now emailed on start;

### DIFF
--- a/IdentityExp1/.well-known/ReadMe.txt
+++ b/IdentityExp1/.well-known/ReadMe.txt
@@ -1,0 +1,1 @@
+This directory must exist to validate LetsEncrypt ownership, to facilitate certificate issue and update.

--- a/IdentityExp1/Code/Constants.cs
+++ b/IdentityExp1/Code/Constants.cs
@@ -25,6 +25,7 @@ namespace NZ01
         ///////////////////////////////////////////////////////////////////////
         // GENERIC
 
+        public static readonly string FNSUFFIX = "() - ";
         public static readonly string MIME_JSON = "application/json";
 
         public static readonly string DATEONLYFORMAT = "yyyy-MM-dd";

--- a/IdentityExp1/Email/EmailContext.cs
+++ b/IdentityExp1/Email/EmailContext.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Newtonsoft.Json;
+
+namespace NZ01
+{
+    public class EmailContext
+    {
+        public string To { get; set; }
+        public string From { get; set; }
+        public string Subject { get; set; }
+        public string Body { get; set; }
+
+        public List<string> Errors { get; } = new List<string>();
+
+        public bool IsCompleted { get; set; }
+    }
+}

--- a/IdentityExp1/Email/EmailOptions.cs
+++ b/IdentityExp1/Email/EmailOptions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NZ01
+{
+    public class EmailOptions
+    {
+        public string To { get; set; }
+        public string From { get; set; }
+        public string Host { get; set; }
+        public bool EnableSsl { get; set; } = false;
+        public int Port { get; set; } = 0;
+        public string Username { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/IdentityExp1/Email/EmailService.cs
+++ b/IdentityExp1/Email/EmailService.cs
@@ -1,0 +1,359 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging; // ILogger
+using Microsoft.Extensions.Options; // IOptions
+//using Microsoft.Extensions.Configuration;
+
+using MailKit.Net.Smtp;
+using MailKit;
+using MimeKit;
+
+using Newtonsoft.Json;
+
+using System.Threading;
+using System.Collections.Concurrent;
+
+
+
+namespace NZ01
+{
+
+    public interface IEmailService
+    {
+        bool Enqueue(EmailContext emailContext);
+        void Clear();
+        void Stop();
+
+        // Properties
+        bool WarnFlag { get; set; }
+        bool ErrorFlag { get; set; }
+        int ThresholdLevelWarn { get; set; }
+        int ThresholdLevelError { get; set; }
+    }
+
+    /// <summary>
+    /// Class to encapsulate a service that will send emails.
+    /// </summary>
+    /// <remarks>
+    /// This requires an entry in the config for EmailOptions.
+    /// WARNING: Do not use _logger.LogWarning() or _logger.LogError(), 
+    /// as this may cause an infinite loop.  
+    /// Consider an error that occurs in email, and this is logged,
+    /// and the logger is configured to email errors, so this is 
+    /// added to the email queue, and the email errors, and we loop infinitely.  
+    /// To combat this, the log message text can contain ERROR or WARNING, so 
+    /// that such entries can still quickly be found in the logs.
+    /// </remarks>
+    public class EmailService : IEmailService
+    {
+        public static readonly string EMAIL_PASSWORD = "CORE_EMAIL_PASSWORD"; // Environment variable key
+
+        private readonly ILogger _logger; // Do not use Logger.LogError() or Logger.LogWarning() within this class, else, BOOM! Infinite Loop.
+        private readonly EmailOptions _emailOptions;
+
+        private ConcurrentQueue<EmailContext> _queue = new ConcurrentQueue<EmailContext>();
+
+        private Thread _thread;
+        private readonly string _threadName = "EmailService";
+        private bool _running = true;
+        private AutoResetEvent _eventThreadExit = new AutoResetEvent(false);
+        private AutoResetEvent _eventThreadAction = new AutoResetEvent(false);
+        private int _waitTimeout = 1000; // 1 second - Effects responsiveness to shutdown
+        
+
+
+        // Properties
+        public int ThresholdLevelWarn { get; set; } = 100; // Warn but accept messages if this number of messages is on the queue
+        public int ThresholdLevelError { get; set; } = 1000; // Error and reject messages if this number of messages is on the queue
+
+        public bool WarnFlag { get; set; } = false;
+        public bool ErrorFlag { get; set; } = false;
+
+
+
+
+        public EmailService(
+            ILogger<EmailService> logger,
+            IOptions<EmailOptions> options)
+        {
+            string prefix = nameof(EmailService) + Constants.FNSUFFIX + " [CTOR] ";
+
+            _logger = logger;
+            _emailOptions = options.Value;
+
+            _thread = new Thread(new ThreadStart(runThread));
+            _thread.Name = _threadName;
+            _thread.IsBackground = true; // Thread will be stopped like a pool thread if app is closed.
+
+            _logger.LogInformation(prefix + $"About to start {_threadName} Thread...");
+            _thread.Start();
+            _logger.LogInformation(prefix + $"{_threadName} Thread started...");
+
+            _logger.LogDebug(prefix + "Entering/Exiting");
+        }
+
+
+        /// <summary>
+        /// Add an email context to the queue to send.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public bool Enqueue(EmailContext context)
+        {
+            int countQueued = _queue.Count;
+            if (checkCapacity(countQueued))
+            {
+                _queue.Enqueue(context);
+                _eventThreadAction.Set();
+                return true;
+            }
+            else
+                return false;
+        }
+
+        /// <summary>
+        /// Clear the queue if something is wrong
+        /// </summary>
+        public void Clear()
+        {
+            string prefix = nameof(Clear) + Constants.FNSUFFIX;
+
+            _queue = new ConcurrentQueue<EmailContext>(); // Quickest way to clear the queue is to swap in a new one. Ref: https://social.msdn.microsoft.com/Forums/en-US/accf4254-ee81-4059-9251-619bc6bbeadf/clear-a-concurrentqueue?forum=rx
+
+            _logger.LogInformation(prefix + "WARNING: The contents of the email queue have been cleared.");
+        }
+
+        /// <summary>
+        /// Stop processing the queue as a prelude to shutting down.
+        /// </summary>
+        public void Stop()
+        {
+            string prefix = nameof(Stop) + Constants.FNSUFFIX;
+
+            _running = false; // Stops the thread wait infinite loop
+
+            if (_eventThreadExit.WaitOne())
+                _logger.LogInformation(prefix + $"Graceful Shutdown - {_threadName} Thread has signalled that it has stopped.");
+            else
+                _logger.LogInformation(prefix + $"Bad Shutdown - {_threadName} Thread did not signal that it had stopped.");
+        }
+
+
+
+        private void runThread()
+        {
+            while (_running)
+            {
+                if (_eventThreadAction.WaitOne(_waitTimeout))
+                    consumeQueue(); // Signal Received                
+            }
+
+            // Signal that the thread has exited.
+            _eventThreadExit.Set();
+        }
+
+
+        /// <summary>
+        /// Check all required settings have value
+        /// </summary>
+        /// <param name="password"></param>
+        /// <returns></returns>
+        private bool validSettings(string password)
+        {
+            string prefix = nameof(validSettings) + Constants.FNSUFFIX;
+
+            List<string> errors = new List<string>();
+
+            if (string.IsNullOrWhiteSpace(password)) errors.Add($"No password set in env var {EMAIL_PASSWORD}");
+            if (string.IsNullOrWhiteSpace(_emailOptions.Host)) errors.Add("Email Host missing");
+            if (_emailOptions.Port <= 0) errors.Add($"Port is invalid:[{_emailOptions.Port}]");
+            if (string.IsNullOrWhiteSpace(_emailOptions.Username)) errors.Add("Email Username missing");
+
+            string sErrors = string.Join("; ", errors);
+            int iCountErrors = errors.Count;
+
+            if (errors.Count > 0)
+            {
+                _logger.LogInformation(prefix + $"ERROR: Email Options are not configured correctly; Errors:[{sErrors}]");
+                return false;
+            }
+
+            return true;
+        }
+
+        private void consumeQueue()
+        {
+            string prefix = nameof(consumeQueue) + Constants.FNSUFFIX;
+
+            if (!validSettings(_emailOptions.Password))
+                return;
+
+            // Make one connection to email server for all emails to send
+            using (var client = new SmtpClient())
+            {
+                try
+                {
+                    client.ServerCertificateValidationCallback = ((s, c, h, e) => true);
+
+                    client.Connect(
+                        _emailOptions.Host,
+                        _emailOptions.Port,
+                        _emailOptions.EnableSsl);
+
+                    client.AuthenticationMechanisms.Remove("XOAUTH2");
+
+                    client.Authenticate(_emailOptions.Username, _emailOptions.Password);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogInformation(prefix + $"ERROR: Exception during attempt to connect to email server; Exception:[{ex.ToString()}]");
+                    return;
+                }
+
+                if (!client.IsConnected)
+                {
+                    _logger.LogInformation(prefix + $"ERROR: Failed to connect to email server;  No exception occurred, but SMTP client is not connected.");
+                    client.Disconnect(true);
+                    return;
+                }
+
+                if (!client.IsAuthenticated)
+                {
+                    _logger.LogInformation(prefix + $"ERROR: Connection to email server was successful but SMTP client is not authenticated.");
+                    client.Disconnect(true);
+                    return;
+                }
+
+                // Should be connected and authenticated
+                EmailContext emailContext = null;
+                while (_queue.TryDequeue(out emailContext))
+                {
+                    processQueuedItem(client, emailContext, _queue.Count);
+                }
+
+                client.Disconnect(true);
+
+            } // end of using()
+
+        }
+
+        private ICollection<string> processAddressField(string addressField, string addressFieldDefault, char[] delimiters)
+        {
+            List<string> addresses = new List<string>();
+
+            if (string.IsNullOrWhiteSpace(addressField))
+            {
+                if (!string.IsNullOrWhiteSpace(addressFieldDefault))
+                    addresses.Add(addressFieldDefault);
+            }
+            else
+            {
+                string[] arrAddresses = addressField.Split(delimiters);
+                foreach (string addr in arrAddresses)
+                {
+                    addresses.Add(addr);
+                }
+            }
+
+            return addresses;
+        }
+
+        private void processQueuedItem(SmtpClient client, EmailContext emailContext, int countQueued)
+        {
+            string prefix = nameof(processQueuedItem) + Constants.FNSUFFIX;
+
+            _logger.LogInformation(prefix + $"About to attempt send for Context:[{JsonConvert.SerializeObject(emailContext)}]");
+
+            char[] delimiters = new char[] { ',', ';', ' ' }; // Permit addresses to be separated by commas, semis or spaces
+            List<string> addressesTo = (List<string>)processAddressField(emailContext.To, _emailOptions.To, delimiters);
+            List<string> addressesFrom = (List<string>)processAddressField(emailContext.From, _emailOptions.From, delimiters);
+
+            if (addressesTo.Count == 0)
+            {
+                string error = "The receiver (To) address list is empty.";
+                emailContext.Errors.Add(error);
+                emailContext.IsCompleted = true;
+                _logger.LogInformation(prefix + $"ERROR: Not sending this message; " + error);
+                return;
+            }
+
+            if (addressesFrom.Count == 0)
+            {
+                string error = "The send (From) address list is empty.";
+                emailContext.Errors.Add(error);
+                emailContext.IsCompleted = true;
+                _logger.LogInformation(prefix + $"ERROR: Not sending this message; " + error);
+                return;
+            }
+
+
+            var message = new MimeMessage();
+
+            foreach (string addressTo in addressesTo)
+                message.To.Add(new MailboxAddress(addressTo));
+
+            foreach (string addressFrom in addressesFrom)
+                message.From.Add(new MailboxAddress(addressFrom));
+
+            message.Subject = string.IsNullOrWhiteSpace(emailContext.Subject) ? "(no subject)" : emailContext.Subject;
+
+            string body = string.IsNullOrWhiteSpace(emailContext.Body) ? "(no email body text)" : emailContext.Body;
+            message.Body = new TextPart("plain") { Text = body };
+
+            try
+            {
+                client.Send(message);
+            }
+            catch (Exception ex)
+            {
+                string error = $"Exception:[{ex.ToString()}].";
+                emailContext.Errors.Add(error);
+                emailContext.IsCompleted = true;
+                _logger.LogInformation(prefix + $"ERROR: Exception during Send() attempt for Context:[{JsonConvert.SerializeObject(emailContext)}]; " + error);
+                return;
+            }
+
+            emailContext.IsCompleted = true;
+            _logger.LogInformation(prefix + $"Send completed for Context:[{JsonConvert.SerializeObject(emailContext)}]");
+        }
+
+
+
+
+
+        ///////////////////////////////////////////////////////////////////////////////////
+        // HELPERS
+        //
+
+        private bool checkCapacity(int countQueued)
+        {
+            string prefix = nameof(checkCapacity) + Constants.FNSUFFIX;
+
+            if (countQueued > ThresholdLevelWarn && WarnFlag == false)
+            {
+                WarnFlag = true;
+
+                string msg = $"WARNING: The {_threadName} message queue has passed {ThresholdLevelWarn} messages.";
+                _logger.LogInformation(prefix + msg);
+            }
+
+            if (countQueued > ThresholdLevelError)
+            {
+                if (ErrorFlag == false)
+                {
+                    ErrorFlag = true;
+
+                    string msg = $"ERROR: The {_threadName} message queue has passed {ThresholdLevelError} messages";
+                    _logger.LogInformation(prefix + msg);
+                }
+
+                return false; // Do not add this message to queue
+            }
+
+            return true; // Queue message
+        }
+    }
+}

--- a/IdentityExp1/IdentityExp1.csproj
+++ b/IdentityExp1/IdentityExp1.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="MailKit" Version="1.18.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="1.1.2" />

--- a/IdentityExp1/Logging/log4Net/Log4NetExtensions.cs
+++ b/IdentityExp1/Logging/log4Net/Log4NetExtensions.cs
@@ -7,14 +7,17 @@ using Microsoft.Extensions.Logging;
 
 namespace NZ01
 {
-    public static class Log4netExtensions
+    public static class Log4NetExtensions
     {
         public static int CountCalls_AddLog4Net { get; set; } = 0;
 
-        public static ILoggerFactory AddLog4Net(this ILoggerFactory factory)
+        public static ILoggerFactory AddLog4Net(this ILoggerFactory factory, IEmailService emailService = null)
         {
             ++CountCalls_AddLog4Net;
             factory.AddProvider(new Log4NetProvider("App"));
+
+            Log4NetAsyncLog.IEmailService = emailService; // Set the email service for the provider; Null value should be tolerated.
+
             return factory;
         }
     }

--- a/IdentityExp1/Logging/log4Net/Log4NetLogger.cs
+++ b/IdentityExp1/Logging/log4Net/Log4NetLogger.cs
@@ -17,6 +17,7 @@ namespace NZ01
         public static int CountCalls_IsEnabled { get; set; } = 0;
         public static int CountCalls_Log { get; set; } = 0;
 
+
         public Log4NetLogger(string name)
         {
             ++CountCalls_InstanceCtor;

--- a/IdentityExp1/appsettings.json
+++ b/IdentityExp1/appsettings.json
@@ -1,5 +1,21 @@
 ﻿{
   "Option1": "This data is held in appsettings.json",
+  "EmailOptions": {
+    "To": "hiblet@yahoo.com",
+    "From": "facelessDevTeam@gmail.com",
+    "Host": "smtp.gmail.com",
+    "EnableSsl": false,
+    "Port": 587,
+    "Username": "facelessdevteam@gmail.com"
+  },
+  "EmailOptionsProduction": {
+    "To": "hiblet@yahoo.com",
+    "From": "facelessDevTeam@gmail.com",
+    "Host": "127.0.0.1",
+    "EnableSsl": false,
+    "Port": 25,
+    "Username": "info@cryptocommoditygroup.co.uk"
+  },
   "JwtIssuerOptions": {
     "Issuer": "TokenServer",
     "Audience": "TokenConsumer",
@@ -27,7 +43,7 @@
     "ClientIdHeader": "X-ClientId",
     "HttpStatusCode": 429,
     "IpWhitelist": [ "8.8.8.8", "192.168.0.0/24" ],
-    "EndpointWhitelist": [ ],
+    "EndpointWhitelist": [],
     "ClientWhitelist": [ "Admin" ],
     "GeneralRules": [
       {
@@ -61,8 +77,8 @@
     "EnableEndpointRateLimiting": true,
     "ClientIdHeader": "X-ClientId",
     "HttpStatusCode": 429,
-    "EndpointWhitelist": [ ],
-    "ClientWhitelist": ["Admin"],
+    "EndpointWhitelist": [],
+    "ClientWhitelist": [ "Admin" ],
     "GeneralRules": [
       {
         "Endpoint": "*",

--- a/IdentityExp1Test/IdentityExp1Test.csproj
+++ b/IdentityExp1Test/IdentityExp1Test.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MailKit" Version="1.18.0" />
     <PackageReference Include="Microsoft.AspNetCore.Rewrite" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />


### PR DESCRIPTION
BRANCH: 2017-08-10_LT3_EmailLogs


CHANGED: IdentityExp1/Startup.cs
 - Configuration member variable renamed to match LoginWithJwtExp1.
 - Logger member variable added.
 - ConfigureServices() updated to include EmailService section to load config and set up singleton instance of EmailService.
 - Configure() updated to take injected emailService and add it to log4Net.
 - Configure() calls app.UseStaticFiles() now as this is required for all normal static files.
 - Configure() calls _logger.LogWarning() to send email on startup.

ADDED: Email classes
 - EmailContext, EmailOptions and EmailServices class files added.

CHANGED: Log4Net wrappers
 - Email versions of Log4Net wrappers included.

CHANGED: IdentityExp1/appsettings.json
 - EmailOptions section added for Development and Production.

CHANGED: IdentityExp1/IdentityExp1.csproj (and Test)
 - MailKit added from Nuget.

CHANGED: IdentityExp1/Code/Constants.cs
 - FNSUFFIX value added.

MOVED: Constants.cs
 - From root IdentityExp1 to IdentityExp1/Code

ADDED: IdentityExp1/.well-known/ReadMe.txt
 - Dummy file added to persist directory.